### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,34 @@
-
-
-
-
-
 # HtmlRecycler
-Converts a simple html page into A `RecyclerView` of Native android widgets powered by [Jsoup library](https://jsoup.org/) and inspired by [Medium Textview](https://github.com/angebagui/medium-textview/)
+Converts a simple html page into A `RecyclerView` of native android widgets powered by [Jsoup library](https://jsoup.org/) and inspired by [Medium Textview](https://github.com/angebagui/medium-textview/)
 
 > ***Note this is under development and  unstable***
 
+## Add it to your project
+```
+dependencies {
+    implementation 'com.github.m7mdra:HtmlRecycler:0.1.1'
+}
+```
 
-### demo
- 
-|  |  |
-|--|--|
-| ![enter image description here](https://raw.githubusercontent.com/m7mdra/HtmlRecycler/master/media/demo1.gif) | ![enter image description here](https://raw.githubusercontent.com/m7mdra/HtmlRecycler/master/media/demo2.gif) |
+This project is distributed using jitpack. Make sure you add it as a maven repository to your `build.gradle`
+```
+allprojects {
+    repositories {
+        maven { 
+            url 'https://jitpack.io' 
+        }
+    }
+}
+```
+
+## Demo
+| ![demo1](https://raw.githubusercontent.com/m7mdra/HtmlRecycler/master/media/demo1.gif) | ![demo2](https://raw.githubusercontent.com/m7mdra/HtmlRecycler/master/media/demo2.gif) |
 
  - [APK](https://cdn.rawgit.com/m7mdra/HtmlRecycler/d278854a/app/build/outputs/apk/debug/app-debug.apk) 
- - Or simply `git clone` the repository and build the `app` moudle. 
+ - Or simply `git clone` the repository and build the `app` module. 
  
  
-## Currently supported html elements:
-
+## Currently supported html elements
  - [x] Paragraph 
  - [x] H1...H6
  - [x] Image
@@ -34,120 +42,82 @@ Converts a simple html page into A `RecyclerView` of Native android widgets powe
  - [ ] Table
  - [x] DIV 
 
-## Implement in your project ? 
-
+## Implementation
 ```
 val networkSource = NetworkSource("https://gist.githubusercontent.com/m7mdra/f22c62bc6941e08064b4fbceb4832a90/raw/ea8574d986635cf214541f1f5702ef37cc731aaf/article.html")  
   
 HtmlRecycler.Builder(this@MainActivity)  
-        .setSource(networkSource)  
-        .setAdapter(DefaultElementsAdapter(this@MainActivity)
-         { element, i, view ->  
-          
-        }}).setRecyclerView(recyclerView)  
-        .setLoadingCallback(object : HtmlRecycler.LoadCallback {  
-            override fun onLoadingStart() {  
-                progressBar.visibility = View.VISIBLE  
-  }  
-  
-            override fun onLoaded(document: Document?) {  
-                progressBar.visibility = View.GONE
-  
-  }  
-        })  
-        .build()
+    .setSource(networkSource)  
+    .setAdapter(DefaultElementsAdapter(this@MainActivity) { element, i, view ->  
+    }})
+    .setRecyclerView(recyclerView)  
+    .setLoadingCallback(object : HtmlRecycler.LoadCallback {  
+        override fun onLoadingStart() {  
+            progressBar.visibility = View.VISIBLE  
+        }  
+        override fun onLoaded(document: Document?) {  
+            progressBar.visibility = View.GONE
+  	}  
+    })  
+    .build()
 ```
 
-the above code uses the existing implementation of `DefaultElementsAdapter` which `extends` `ElementsAdapter` class which inherently is a `RecylcerView Adpater`  
-the `DefaultElementsAdapter` uses a layout resources files defined by me but they not styled probably and are very buggy(especially the video, audio and iframe ones)
+The above code uses the existing implementation of `DefaultElementsAdapter` which `extends` `ElementsAdapter` class which inherently is a `RecylcerView Adpater` the `DefaultElementsAdapter` uses a layout resources files defined by me but they not styled probably and are very buggy (especially the video, audio and iframe ones).
 
-want to create your own adapter ? just simply extend `ElementsAdapter`
-and override methods
-
-      
-	class BetterImplementationThanTheAuthorsAdapter : ElementsAdapter() {  
-  
+Want to create your own adapter? just simply extend `ElementsAdapter` and override methods:
+```
+class BetterImplementationThanTheAuthorsAdapter : ElementsAdapter() {    
     override fun onCreateElement(parent: ViewGroup, elementType: ElementType): RecyclerView.ViewHolder {  
         when (elementType) {  
             ElementType.Paragraph -> {  
                 return ParagraphViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.row_paragarph, parent, false))  
-            }  
-            //.  
-			// .
-			// .
-			//other elements defined here  }  
+            }
+	    // Define other elements here
+        }  
     }  
   
     override fun onBindElement(holder: RecyclerView.ViewHolder, position: Int) {  
         val element = elements[position] //current element  
-	  if (holder is ParagraphViewHolder){  
-            val paragraphElement = element as ParagraphElement  
-            holder.paragraphText.text= paragraphElement.text  
-		  }  
+	    if (holder is ParagraphViewHolder){  
+                val paragraphElement = element as ParagraphElement  
+            	holder.paragraphText.text= paragraphElement.text  
 	    }  
+	}  
     }
-after that replace your adapter with the default implementation
+}
+```
 
-    HtmlRecycler.Builder(this)  
-        .setSource(StringSource(Data.data))  
-        .setAdapter(BetterImplementationThanTheAuthorsAdapter()) // this is a custom adapter  
-	    .setRecyclerView(recyclerView)  
-        .build()
+Then replace the default adapter with your adapter:
+```
+HtmlRecycler.Builder(this)  
+    .setSource(StringSource(Data.data))  
+    .setAdapter(BetterImplementationThanTheAuthorsAdapter()) // this is a custom adapter  
+    .setRecyclerView(recyclerView)  
+    .build()
+```
+
 ### How to add Data
-
-Data can come from different sources , the library support the following
+Data can come from different sources, the library support the following:
 
  - [x] Assets
  - [x] File
  - [x] String
  - [x] Network (runs on `UI thread` by default so you have to run it on different thread or write your own Source Implementation )
-### Write your own source ?
-simply implement the `Source` interface which will return a `Document` of the parsed Source
 
-    class FileSource(val file: File) : Source {  
+### Write your own source
+Simply implement the `Source` interface which will return a `Document` of the parsed `Source`:
+```
+class FileSource(val file: File) : Source {  
     override fun get(): Document {  
         return Jsoup.parse(file, "UTF-8")  
-	    }  
-    }
-## attach Click listeners on elements?
-in `DefaultElemetsAdapter` class at line [#27](https://github.com/m7mdra/HtmlRecylcer/blob/master/htmlrecycler/src/main/java/m7mdra/com/htmlrecycler/adapter/DefaultElementsAdapter.kt#L27) l i defined a [higher-order-function](https://kotlinlang.org/docs/reference/lambdas.html#higher-order-functions) in the constructor method (which dose the same as defining an interface) and on line [#75](https://github.com/m7mdra/HtmlRecylcer/blob/master/htmlrecycler/src/main/java/m7mdra/com/htmlrecycler/adapter/DefaultElementsAdapter.kt#L75) we envoke the method passing our element and the position of the clicked view.
-## Add to your project?
-Add it in your root build.gradle at the end of repositories:
-**Gradle**
-```css
-	allprojects {
-		repositories {
-			...
-			maven { url 'https://jitpack.io' }
-		}
-	}
+    }  
+}
 ```
 
-**Step 2.**  Add the dependency
+## Attach Click listeners on elements
+In `DefaultElemetsAdapter` class at line [#27](https://github.com/m7mdra/HtmlRecylcer/blob/master/htmlrecycler/src/main/java/m7mdra/com/htmlrecycler/adapter/DefaultElementsAdapter.kt#L27) l i defined a [higher-order-function](https://kotlinlang.org/docs/reference/lambdas.html#higher-order-functions) in the constructor method (which dose the same as defining an interface) and on line [#75](https://github.com/m7mdra/HtmlRecylcer/blob/master/htmlrecycler/src/main/java/m7mdra/com/htmlrecycler/adapter/DefaultElementsAdapter.kt#L75) we envoke the method passing our element and the position of the clicked view.
 
-```css
-	dependencies {
-	        implementation 'com.github.m7mdra:HtmlRecycler:0.1.1'
-	}
-```
-**Maven**
-```markup
-<repositories>
-		<repository>
-		    <id>jitpack.io</id>
-		    <url>https://jitpack.io</url>
-		</repository>
-	</repositories>
-```
-```markup
-	<dependency>
-	    <groupId>com.github.m7mdra</groupId>
-	    <artifactId>HtmlRecycler</artifactId>
-	    <version>0.1.1</version>
-	</dependency>
-```
 ## TODO list: 
-
  - [ ] Define a standard Layout styling.
  - [x] allow `NetworkSource` to run on `UI thread` without crashing. 
  - [ ] Support the following elements:


### PR DESCRIPTION
* Moved dependency information near the top
* Removed maven instructions
* Fixed spacing in snippets. Keeping 4 space convention

I've fixed up a couple errors I saw when reading your README. I think the biggest change was removing maven instructions, and moving dependency information to the top. 

People interested in your library will want to quickly get that dependency information, even before the demo. I highly doubt people are using maven directly for their Android dependencies. Folks that are still using maven should be informed enough to deduce the dependency from Gradle. If you disagree feel free to put it back in though.